### PR TITLE
Fix for addExtension

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -590,7 +590,9 @@ FirefoxProfile.prototype._installExtension = function(addon, cb) {
           wrench.rmdirRecursive(tmpDir, function() {
             next();
           });
+          return;
         }
+        next();
       }
     ], function() {
       // done!


### PR DESCRIPTION
Hi guys,
I ran into an issue with adding an unpacked extension to the profile - when using addExtension with path to unpacked extension it wouldn't call a callback.
That is easy fix.
